### PR TITLE
fix license field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "ZOS"
   ],
   "author": "ccw",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "xxxxdevDependencies": {
     "node-gyp": "^3.8.0"
   },


### PR DESCRIPTION
The LICENSE file in this repository is Apache License 2.0 rather than ISC.