### PR TITLE
enable mvsutils to compile with clang

### DIFF
--- a/addon.cc
+++ b/addon.cc
@@ -1,6 +1,6 @@
 /*
  * Licensed Materials - Property of IBM
- * (C) Copyright IBM Corp. 2019. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2022. All Rights Reserved.
  * US Government Users Restricted Rights - Use, duplication or disclosure
  * restricted by GSA ADP Schedule Contract with IBM Corp.
  */

--- a/addon.cc
+++ b/addon.cc
@@ -38,14 +38,12 @@ protected:
   void Execute() override {}
   void OnOK() override {
     Napi::Env env = Env();
-
     Callback().MakeCallback(Receiver().Value(),
                             {error.Value(), env.Undefined()});
   }
 
   void OnError(const Napi::Error &e) override {
     Napi::Env env = Env();
-
     Callback().MakeCallback(Receiver().Value(), {e.Value(), env.Undefined()});
   }
 
@@ -108,7 +106,7 @@ Napi::Number ConsoleSync(const Napi::CallbackInfo &info) {
   }
 
   std::stringstream message;
-  for (int i = 0; i < info.Length(); ++i) {
+  for (size_t i = 0; i < info.Length(); ++i) {
     message << info[i].ToString().Utf8Value();
     if (i < (info.Length() - 1))
       message << " ";
@@ -130,7 +128,7 @@ Napi::Value GetFileCcsid(const Napi::CallbackInfo &info) {
   if (info[0].IsNumber()) {
     int fd = info[0].As<Napi::Number>();
     struct stat st;
-    int rc, err;
+    int rc;
     rc = fstat(fd, &st);
     if (rc != 0) {
       res.Set("error",
@@ -140,10 +138,9 @@ Napi::Value GetFileCcsid(const Napi::CallbackInfo &info) {
       res.Set("ccsid", st.st_tag.ft_ccsid);
     }
   } else {
-    const char *tmp = info[0].ToString().Utf8Value().c_str();
-    strncpy(filename, tmp, 1024);
+    strncpy(filename, info[0].ToString().Utf8Value().c_str(), 1024);
     struct stat st;
-    int rc, err;
+    int rc;
     rc = stat(filename, &st);
     if (rc != 0) {
       res.Set("error", errstring(message, 1024, errno, "stat error on file %s ",
@@ -171,8 +168,7 @@ Napi::Value SetFileCcsid(const Napi::CallbackInfo &info) {
   if (info[0].IsNumber()) {
     fd = info[0].As<Napi::Number>();
   } else {
-    const char *tmp = info[0].ToString().Utf8Value().c_str();
-    strncpy(filename, tmp, 1024);
+    strncpy(filename, info[0].ToString().Utf8Value().c_str(), 1024);
   }
   int text;
   int ccsid;
@@ -235,7 +231,6 @@ Napi::Value GuessFileCcsid(const Napi::CallbackInfo &info) {
   Napi::Object res = Napi::Object::New(env);
   char message[1024];
   char filename[1024];
-  int ccsid = 0;
   int fd = -1;
   if (info.Length() < 1) {
     Napi::Error::New(env, "Need file name or file descriptor as argument")
@@ -247,8 +242,7 @@ Napi::Value GuessFileCcsid(const Napi::CallbackInfo &info) {
     fd = info[0].As<Napi::Number>();
     res.Set("fd", fd);
   } else {
-    const char *tmp = info[0].ToString().Utf8Value().c_str();
-    strncpy(filename, tmp, 1024);
+    strncpy(filename, info[0].ToString().Utf8Value().c_str(), 1024);
     fd = open(filename, O_RDONLY);
     if (-1 == fd) {
       res.Set("error",

--- a/addon.cc
+++ b/addon.cc
@@ -96,8 +96,17 @@ private:
   int result;
 };
 
+int logging = 0;
+
 Napi::Number ConsoleSync(const Napi::CallbackInfo &info) {
   __ae_runmode ae(__AE_ASCII_MODE);
+   
+  char *logenv = getenv("MVSUTILS_LOG");
+  if (logenv && 0 == strcmp("console", logenv)) {
+    logging = 1;
+  }
+  if (logging)
+    fprintf(stderr, "In ConsoleSync\n");
   Napi::Env env = info.Env();
   if (info.Length() < 1) {
     Napi::Error::New(env, "Need at least one string as argument")
@@ -105,13 +114,21 @@ Napi::Number ConsoleSync(const Napi::CallbackInfo &info) {
     return Napi::Number::New(env, -1);
   }
 
+  if (logging)
+    fprintf(stderr, "In ConsoleSync: Constructing message...\n");
+
   std::stringstream message;
   for (size_t i = 0; i < info.Length(); ++i) {
     message << info[i].ToString().Utf8Value();
     if (i < (info.Length() - 1))
       message << " ";
   }
+  if (logging)
+    fprintf(stderr, "In ConsoleSync: Console Log message: %s\n", message.str().c_str());
+
   __con_print(message.str().c_str());
+  if (logging)
+    fprintf(stderr, "Exiting ConsoleSync\n");
   return Napi::Number::New(env, 0);
 }
 Napi::Value GetFileCcsid(const Napi::CallbackInfo &info) {

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,10 +1,6 @@
 {
     "targets": [{
         "target_name": "mvsutils",
-        "cflags!": [ "-fno-exceptions"],
-        "cflags": [  "-qascii" ],
-        "cflags_cc!": ["-fno-exceptions" ],
-        "cflags_cc": ["-qascii" ],
         "include_dirs": [
             "<!@(node -p \"require('node-addon-api').include\")"
         ],
@@ -23,7 +19,6 @@
         "dependencies": [
             "<!(node -p \"require('node-addon-api').gyp\")"
         ],
-        "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS", "_AE_BIMODAL=1", "_ALL_SOURCE", "_ENHANCED_ASCII_EXT=0x42020010", "_LARGE_TIME_API", "_OPEN_MSGQ_EXT", "_OPEN_SYS_FILE_EXT=1", "_OPEN_SYS_SOCK_IPV6", "_UNIX03_SOURCE", "_UNIX03_THREADS", "_UNIX03_WITHDRAWN", "_XOPEN_SOURCE=600", "_XOPEN_SOURCE_EXTENDED", 
-        ]
+        "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS" ]
     }]
 }

--- a/console.cc
+++ b/console.cc
@@ -1,6 +1,6 @@
 /*
  * Licensed Materials - Property of IBM
- * (C) Copyright IBM Corp. 2019. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2022. All Rights Reserved.
  * US Government Users Restricted Rights - Use, duplication or disclosure
  * restricted by GSA ADP Schedule Contract with IBM Corp.
  */

--- a/console.cc
+++ b/console.cc
@@ -24,7 +24,11 @@
 #error Not compiled with -qascii
 #endif
 
+extern int logging;
+
 static void __console_multiline(const void *p, unsigned int len) {
+  if (logging)
+    fprintf(stderr, "In __console_multiline: %p - length: %d\n", p, len);
   const unsigned char *str = (const unsigned char *)p;
   static unsigned int _wto_init[] = {
       0x00088050, 0x55555555, 0x02000068, 0x00800000, 0x00000000, 0x00000000,
@@ -78,8 +82,8 @@ static void __console_multiline(const void *p, unsigned int len) {
 #undef WIDTH
 #define WIDTH_1 65
 #define WIDTH 69
-  struct wto_parm *parm =
-      (struct wto_parm *)__malloc31(sizeof(struct wto_parm));
+  struct wto_parm * __ptr32 parm =
+      (struct wto_parm * __ptr32)__malloc31(sizeof(struct wto_parm));
   memcpy(parm, &_wto_init, sizeof(_wto_init));
   int i;
   unsigned char cnt = 0;
@@ -99,14 +103,20 @@ static void __console_multiline(const void *p, unsigned int len) {
       ++cnt;
       break;
     }
+    if (logging)
+      fprintf(stderr, "In __console_multiline: data[first].text_addr: %p, data[first].size: %d\n", parm->textaddr, parm->firstline.size);
 
     for (i = 0; i < 256; ++i) {
+      if (logging)
+        fprintf(stderr, "In __console_multiline: loop i: %d\n", i);
       parm->line[i].text_addr = &parm->content[i];
       parm->line[i].msg_len = 8;
       if (len > WIDTH) {
         parm->line[i].line_type = 0x2000;
         parm->content[i].size = WIDTH;
         memcpy(parm->content[i].buf, str, WIDTH);
+        if (logging)
+          fprintf(stderr, "In __console_multiline: str: %.*s\n", WIDTH, parm->content[i].buf);
         __a2e_l((char *)parm->content[i].buf, WIDTH);
         str += WIDTH;
         len -= WIDTH;
@@ -115,29 +125,48 @@ static void __console_multiline(const void *p, unsigned int len) {
         parm->line[i].line_type = 0x3000;
         parm->content[i].size = len;
         memcpy(parm->content[i].buf, str, len);
+        if (logging)
+          fprintf(stderr, "In __console_multiline: str: %.*s\n", len, parm->content[i].buf);
         __a2e_l((char *)parm->content[i].buf, len);
         str += len;
         len = 0;
         ++cnt;
         break;
       }
+      if (logging)
+        fprintf(stderr, "In __console_multiline: data[%d].text_addr: %p, data[%d].size: %d\n", i, parm->line[i].text_addr, i, parm->line[i].msg_len);
     }
     if (i == 256) {
       parm->line[255].line_type = 0x3000;
     }
+    if (logging)
+      fprintf(stderr, "In __console_multiline: data[%d].text_addr: %p, data[%d].size: %d\n", i, parm->line[i].text_addr, i, parm->line[i].msg_len);
   } while (0);
   parm->total_num_of_lines = cnt;
+
+  if (logging)
+    fprintf(stderr, "In __console_multiline: Writing via svc 35, # of lines: %d\n", parm->total_num_of_lines);
+
   __asm(" la  0,0 \n"
         " lr  1,%0 \n"
         " svc 35 \n"
         : "+NR:r1"(parm)
         :
         : "r0", "r15");
+
+  if (logging)
+    fprintf(stderr, "In __console_multiline: After svc 35, freeing memory\n");
+
   free(parm);
+
+  if (logging)
+    fprintf(stderr, "Existing __console_multiline\n");
 #undef WIDTH_1
 #undef WIDTH
 }
 static void __console(const void *p_in, int len_i) {
+  if (logging)
+    fprintf(stderr, "In __console: %p - length: %d\n", p_in, len_i);
   const unsigned char *p = (const unsigned char *)p_in;
   int len = len_i;
   typedef struct wtob {
@@ -145,23 +174,33 @@ static void __console(const void *p_in, int len_i) {
     unsigned short flags;
     unsigned char msgarea[256];
   } wtob_t;
-  wtob_t *m = (wtob_t *)__malloc31(len + 8);
+  wtob_t * __ptr32 m = (wtob_t * __ptr32)__malloc31(len + 8);
   if (0 == m)
     return;
   m->sz = len + 4;
   m->flags = 0x8000;
   memcpy(m->msgarea, p, len);
+  if (logging)
+    fprintf(stderr, "In __console: msgarea: %.*s\n", len, m->msgarea);
   __a2e_l((char *)m->msgarea, len);
   memcpy(m->msgarea + len, "\x20\x00\x00\x20", 4);
+  if (logging)
+    fprintf(stderr, "In __console: before svc 35 call\n");
   __asm(" la  0,0 \n"
         " lr  1,%0 \n"
         " svc 35 \n"
         :
         : "r"(m)
         : "r0", "r1", "r15");
+  if (logging)
+    fprintf(stderr, "In __console: after svc 35 call, freeing\n");
   free(m);
+  if (logging)
+    fprintf(stderr, "Exiting __console\n");
 }
 extern "C" void __con_print(const char *msg) {
+  if (logging)
+    fprintf(stderr, "In __con_print\n");
   int len = strlen(msg);
   if (len > 126)
     __console_multiline(msg, len);

--- a/errstring.cc
+++ b/errstring.cc
@@ -1,6 +1,6 @@
 /*
  * Licensed Materials - Property of IBM
- * (C) Copyright IBM Corp. 2019. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2022. All Rights Reserved.
  * US Government Users Restricted Rights - Use, duplication or disclosure
  * restricted by GSA ADP Schedule Contract with IBM Corp.
  */

--- a/filescan.cc
+++ b/filescan.cc
@@ -240,11 +240,11 @@ int cp1047scan(char *errmsg, size_t sz, int fd) {
     char *str = buffer;
     unsigned long code_out;
 
-    __asm(" trte %1,%3,b'0000'\n"
-          " jo *-4\n"
-          : "+NR:r3"(bytes), "+NR:r2"(str), "+r"(bytes), "+r"(code_out)
-          : "NR:r1"(_tab_e)
-          : "r1", "r2", "r3");
+   __asm volatile(" trte %1,%3,0\n"
+                  " jo *-4\n"
+                  : "+NR:r3"(bytes), "+NR:r2"(str), "+r"(bytes), "+r"(code_out)
+                  : "NR:r1"(_tab_e)
+                  :);
     if ((str - buffer) != b) {
       snprintf(errmsg, sz, "Character not belong to CP 1047 found");
       return -1;

--- a/filescan.cc
+++ b/filescan.cc
@@ -1,6 +1,6 @@
 /*
  * Licensed Materials - Property of IBM
- * (C) Copyright IBM Corp. 2019. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2022. All Rights Reserved.
  * US Government Users Restricted Rights - Use, duplication or disclosure
  * restricted by GSA ADP Schedule Contract with IBM Corp.
  */

--- a/filescan.cc
+++ b/filescan.cc
@@ -264,7 +264,7 @@ int filescan(char *errmsg, size_t sz, int fd) {
     errstring(errmsg, sz, errno, "lseek error on fd %d", fd);
     return -1;
   }
-  int rc = lseek(fd, 0, SEEK_SET);
+  original = lseek(fd, 0, SEEK_SET);
   if (-1 == original) {
     errstring(errmsg, sz, errno, "lseek error on fd %d", fd);
     return -1;

--- a/mvsutils.h
+++ b/mvsutils.h
@@ -1,6 +1,6 @@
 /*
  * Licensed Materials - Property of IBM
- * (C) Copyright IBM Corp. 2019. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2022. All Rights Reserved.
  * US Government Users Restricted Rights - Use, duplication or disclosure
  * restricted by GSA ADP Schedule Contract with IBM Corp.
  */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mvsutils",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "node-js addon to interface with misc MVS resources",
   "main": "index.js",
   "gypfile": true,

--- a/test/test1.js
+++ b/test/test1.js
@@ -1,6 +1,6 @@
 /*
  * Licensed Materials - Property of IBM
- * (C) Copyright IBM Corp. 2019. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2022. All Rights Reserved.
  * US Government Users Restricted Rights - Use, duplication or disclosure
  * restricted by GSA ADP Schedule Contract with IBM Corp.
  */


### PR DESCRIPTION
* Fixes asm statement in filescan.cc so that it compiles with Clang
* Removes -qascii (ascii mode option is common.gypi)
* Removes redundant defines
* Resolves warnings
* Add logging