### PR TITLE
use semantic versioning for dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,13 +21,12 @@
   ],
   "author": "ccw",
   "license": "Apache-2.0",
-  "xxxxdevDependencies": {
-    "node-gyp": ">=3.8.0"
-  },
   "dependencies": {
-    "chai": ">=4.2.0",
-    "mocha": ">=6.2.1",
-    "node-addon-api": ">=1.7.1"
+    "node-addon-api": "^7.1.0"
+  },
+  "devDependencies": {
+    "chai": "^4.4.1",
+    "mocha": "^10.2.0"
   },
   "bugs": {
     "url": "https://github.com/ibmruntimes/mvsutils/issues"
@@ -35,6 +34,5 @@
   "homepage": "https://github.com/ibmruntimes/mvsutils#readme",
   "directories": {
     "test": "test"
-  },
-  "devDependencies": {}
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mvsutils",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "node-js addon to interface with misc MVS resources",
   "main": "index.js",
   "gypfile": true,


### PR DESCRIPTION
As of chai v5.0.0, tests fail to run with error:


> $ npm test
> 
> \> mvsutils@1.0.10 test
> \> ./node_modules/.bin/mocha -b -t 40000 --reporter spec
> 
> 
> Error [ERR_REQUIRE_ESM]: require() of ES Module /home/nodejs/mvsutils/node_modules/chai/chai.js from /home/nodejs/mvsutils/test/test1.js not supported.
> Instead change the require of chai.js in /home/nodejs/mvsutils/test/test1.js to a dynamic import() which is available in all CommonJS modules.
>     at Object.<anonymous> (/home/nodejs/mvsutils/test/test1.js:9:16)
> 

This PR restricts chai to major version 4. Also applies semantic versioning to other dependencies to prevent similar issues from occurring in the future.

Additionally, chai and mocha are used only for testing, so moved them to devDependencies.