### PR TITLE
update Node.js version prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Node.js interface to z/OS resources
 This is a [Node.js](https://nodejs.org/en/) module available through the
 [npm registry](https://www.npmjs.com/).
 -->
-Before installing, [download and install Node.js](https://developer.ibm.com/node/sdk/ztp/).
-Node.js 8.16 for z/OS or higher is required.
+Before installing, [download and install IBM Open Enterprise SDK for Node.js](https://www.ibm.com/docs/en/sdk-nodejs-zos)
+16 or higher. mvsutils v1.0.9 or higher is required for Node.js 18 or higher. 
 
 ```bash
 npm install mvsutils

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mvsutils",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "node-js addon to interface with misc MVS resources",
   "main": "index.js",
   "gypfile": true,


### PR DESCRIPTION
commit https://github.com/ibmruntimes/mvsutils/commit/2f906968be09bb445c1bbe0a1a6f480e755f6b74 upgraded mvsutils to v1.0.9 and enabled mvsutils for clang.

Also update the no-longer-valid link to the Node.js versions.